### PR TITLE
Normalize employer names for joins

### DIFF
--- a/04_ETL_dbt/dbt/project/models/trusted/int_empregados.sql
+++ b/04_ETL_dbt/dbt/project/models/trusted/int_empregados.sql
@@ -43,6 +43,27 @@ with less_v2 as (
     {% endif %}
 
     {{ clean_text('nome') }}                            as nome,
+    nullif(
+      trim(
+        regexp_replace(
+          regexp_replace(
+            regexp_replace(
+              upper(coalesce({{ clean_text('nome') }}, '')),
+              '\\b(S[\\.\\s\\/]*A|BANCO|LTDA)\\b',
+              '',
+              'g'
+            ),
+            '[^A-Z0-9 ]',
+            ' ',
+            'g'
+          ),
+          '\\s+',
+          ' ',
+          'g'
+        )
+      ),
+      ''
+    )                                         as nome_processed,
     cast(match_percent as integer)                      as match_percent,
 
     data_atualizacao,
@@ -83,6 +104,27 @@ v2 as (
     {% endif %}
 
     {{ clean_text('nome') }}                            as nome,
+    nullif(
+      trim(
+        regexp_replace(
+          regexp_replace(
+            regexp_replace(
+              upper(coalesce({{ clean_text('nome') }}, '')),
+              '\\b(S[\\.\\s\\/]*A|BANCO|LTDA)\\b',
+              '',
+              'g'
+            ),
+            '[^A-Z0-9 ]',
+            ' ',
+            'g'
+          ),
+          '\\s+',
+          ' ',
+          'g'
+        )
+      ),
+      ''
+    )                                         as nome_processed,
     cast(match_percent as integer)                      as match_percent,
 
     data_atualizacao,
@@ -91,9 +133,63 @@ v2 as (
 ),
 
 unioned as (
-  select * from less_v2
+  select
+    employer_name,
+    reviews_count,
+    culture_count,
+    salaries_count,
+    benefits_count,
+    employer_website,
+    employer_headquarters,
+    employer_founded,
+    employer_industry,
+    employer_revenue,
+    url,
+    geral,
+    cultura_e_valores,
+    diversidade_e_inclusao,
+    qualidade_de_vida,
+    alta_lideranca,
+    remuneracao_e_beneficios,
+    oportunidades_de_carreira,
+    recomendam_para_outras_pessoas,
+    perspectiva_positiva_da_empresa,
+    segmento,
+    nome,
+    nome_processed,
+    match_percent,
+    data_atualizacao,
+    _source_table
+  from less_v2
   union all
-  select * from v2
+  select
+    employer_name,
+    reviews_count,
+    culture_count,
+    salaries_count,
+    benefits_count,
+    employer_website,
+    employer_headquarters,
+    employer_founded,
+    employer_industry,
+    employer_revenue,
+    url,
+    geral,
+    cultura_e_valores,
+    diversidade_e_inclusao,
+    qualidade_de_vida,
+    alta_lideranca,
+    remuneracao_e_beneficios,
+    oportunidades_de_carreira,
+    recomendam_para_outras_pessoas,
+    perspectiva_positiva_da_empresa,
+    segmento,
+    nome,
+    nome_processed,
+    match_percent,
+    data_atualizacao,
+    _source_table
+  from v2
 ),
 
 final as (

--- a/04_ETL_dbt/dbt/project/models/trusted/mod_empregados.sql
+++ b/04_ETL_dbt/dbt/project/models/trusted/mod_empregados.sql
@@ -6,6 +6,7 @@
     tags=['trusted']
 ) }}
 
+-- Pull through all fields, including nome_processed
 select *
 from {{ ref('int_empregados') }}
 {% if is_incremental() %}

--- a/04_ETL_dbt/dbt/project/models/trusted/mod_empregados.yml
+++ b/04_ETL_dbt/dbt/project/models/trusted/mod_empregados.yml
@@ -1,0 +1,8 @@
+version: 2
+
+models:
+  - name: mod_empregados
+    description: "Dados padronizados de empregadores"
+    columns:
+      - name: nome_processed
+        description: "Nome padronizado do empregador para junção."


### PR DESCRIPTION
## Summary
- standardize employer names via new `nome_processed` column
- expose `nome_processed` through trusted `mod_empregados` model
- document `nome_processed` as normalized employer name

## Testing
- `dbt compile --profiles-dir ../profiles --select int_empregados mod_empregados` *(fails: could not translate host name "postgres" to address)*
- `dbt parse --profiles-dir ../profiles`
- `sqlfluff lint models/trusted/int_empregados.sql --dialect postgres` *(fails: layout operators, indent)*
- `sqlfluff lint models/trusted/mod_empregados.sql --dialect postgres` *(fails: layout indent, long_lines, references)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5e7b9418832591b54ec26c8aaf9e